### PR TITLE
Update the similarity threshold

### DIFF
--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -31,7 +31,7 @@ const handler = async (req: Request): Promise<Response> => {
 
     const { data: chunks, error } = await supabaseAdmin.rpc("pg_search", {
       query_embedding: embedding,
-      similarity_threshold: 0.01,
+      similarity_threshold: 0.5,
       match_count: matches
     });
 

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -27,13 +27,8 @@ const handler = async (req: Request): Promise<Response> => {
 
     const { data: chunks, error } = await supabaseAdmin.rpc("pg_search", {
       query_embedding: embedding,
-<<<<<<< Updated upstream
-      similarity_threshold: 0.5,
-      match_count: matches
-=======
       similarity_threshold: 0.01,
       match_count: 5
->>>>>>> Stashed changes
     });
 
     if (error) {

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -6,33 +6,34 @@ export const config = {
 
 const handler = async (req: Request): Promise<Response> => {
   try {
-    const { query, apiKey, matches } = (await req.json()) as {
-      query: string;
-      apiKey: string;
-      matches: number;
-    };
+    const {query} = (await req.json()) as { query:string };
 
     const input = query.replace(/\n/g, " ");
 
-    const res = await fetch("https://api.openai.com/v1/embeddings", {
+    const response = await fetch("https://api.openai.com/v1/embeddings", {
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY!}`
       },
       method: "POST",
       body: JSON.stringify({
         model: "text-embedding-ada-002",
-        input
+        input: query
       })
     });
 
-    const json = await res.json();
+    const json = await response.json();
     const embedding = json.data[0].embedding;
 
     const { data: chunks, error } = await supabaseAdmin.rpc("pg_search", {
       query_embedding: embedding,
+<<<<<<< Updated upstream
       similarity_threshold: 0.5,
       match_count: matches
+=======
+      similarity_threshold: 0.01,
+      match_count: 5
+>>>>>>> Stashed changes
     });
 
     if (error) {


### PR DESCRIPTION
Currently, the performance is not that good: sometimes searching keywords can't get the texts that included the keywords! Try to adjust the similarity threshold here to include the search results' relevance.